### PR TITLE
Expand migration knowledge collection options

### DIFF
--- a/web/ui/js/ingest.js
+++ b/web/ui/js/ingest.js
@@ -91,7 +91,11 @@ const angularKnowledgePreset = {
   collectionOptions: [
     { value: 'angular_component_catalog', label: 'Angular Component Catalog', selected: true },
     { value: 'angular_service_registry', label: 'Angular Service Registry' },
-    { value: 'angular_module_reference', label: 'Angular Module Reference' }
+    { value: 'angular_module_reference', label: 'Angular Module Reference' },
+    { value: 'angular_patterns_collection', label: 'Angular Patterns Collection' },
+    { value: 'react_patterns_collection', label: 'React Patterns Collection' },
+    { value: 'migration_rules_mappings', label: 'Migration Rules and Mappings' },
+    { value: 'best_practices_knowledge_base', label: 'Best Practices Knowledge Base' }
   ],
   additionalStacks: ['Standalone Components', 'Nx Workspaces', 'Jest Unit Tests'],
   useStackBadges: true


### PR DESCRIPTION
## Summary
- extend the Angular knowledge preset collection list with migration-focused repositories
- add options for Angular and React patterns, migration mappings, and best practices knowledge bases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df19150b5c832f8c112356a0eb48c1