### PR TITLE
Add configurable migration conversion mappings

### DIFF
--- a/internal/workflow/manager.go
+++ b/internal/workflow/manager.go
@@ -94,11 +94,16 @@ type TargetConfig struct {
 }
 
 type MigrationConfig struct {
-	AngularSourceRoot string            `json:"angular_source_root"`
-	AngularVersion    string            `json:"angular_version"`
-	ReactTargetRoot   string            `json:"react_target_root"`
-	ReactVersion      string            `json:"react_version"`
-	PatternMapping    map[string]string `json:"pattern_mapping,omitempty"`
+	AngularSourceRoot          string            `json:"angular_source_root"`
+	AngularVersion             string            `json:"angular_version"`
+	ReactTargetRoot            string            `json:"react_target_root"`
+	ReactVersion               string            `json:"react_version"`
+	PatternMapping             map[string]string `json:"pattern_mapping,omitempty"`
+	ComponentLifecycleMapping  map[string]string `json:"component_lifecycle_mapping,omitempty"`
+	DirectiveConversionMapping map[string]string `json:"directive_conversion_mapping,omitempty"`
+	ServiceContextMapping      map[string]string `json:"service_context_mapping,omitempty"`
+	PipeConversionMapping      map[string]string `json:"pipe_conversion_mapping,omitempty"`
+	GuardRouteMapping          map[string]string `json:"guard_route_mapping,omitempty"`
 }
 
 type Request struct {

--- a/internal/workflow/request.go
+++ b/internal/workflow/request.go
@@ -7,6 +7,25 @@ import (
 	"strings"
 )
 
+func cleanMapping(mapping map[string]string) map[string]string {
+	if len(mapping) == 0 {
+		return nil
+	}
+	cleaned := make(map[string]string, len(mapping))
+	for pattern, target := range mapping {
+		key := strings.TrimSpace(pattern)
+		value := strings.TrimSpace(target)
+		if key == "" || value == "" {
+			continue
+		}
+		cleaned[key] = value
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	return cleaned
+}
+
 func normalizeRequest(req Request) (Request, error) {
 	req.ProjectID = strings.TrimSpace(req.ProjectID)
 	if req.ProjectID == "" {
@@ -83,21 +102,12 @@ func normalizeRequest(req Request) (Request, error) {
 		req.MigrationConfig.ReactTargetRoot = strings.TrimSpace(req.MigrationConfig.ReactTargetRoot)
 		req.MigrationConfig.ReactVersion = strings.TrimSpace(req.MigrationConfig.ReactVersion)
 
-		if len(req.MigrationConfig.PatternMapping) > 0 {
-			cleaned := make(map[string]string, len(req.MigrationConfig.PatternMapping))
-			for pattern, mapping := range req.MigrationConfig.PatternMapping {
-				key := strings.TrimSpace(pattern)
-				value := strings.TrimSpace(mapping)
-				if key != "" && value != "" {
-					cleaned[key] = value
-				}
-			}
-			if len(cleaned) == 0 {
-				req.MigrationConfig.PatternMapping = nil
-			} else {
-				req.MigrationConfig.PatternMapping = cleaned
-			}
-		}
+		req.MigrationConfig.PatternMapping = cleanMapping(req.MigrationConfig.PatternMapping)
+		req.MigrationConfig.ComponentLifecycleMapping = cleanMapping(req.MigrationConfig.ComponentLifecycleMapping)
+		req.MigrationConfig.DirectiveConversionMapping = cleanMapping(req.MigrationConfig.DirectiveConversionMapping)
+		req.MigrationConfig.ServiceContextMapping = cleanMapping(req.MigrationConfig.ServiceContextMapping)
+		req.MigrationConfig.PipeConversionMapping = cleanMapping(req.MigrationConfig.PipeConversionMapping)
+		req.MigrationConfig.GuardRouteMapping = cleanMapping(req.MigrationConfig.GuardRouteMapping)
 
 		if req.MigrationConfig.AngularSourceRoot == "" {
 			return Request{}, fmt.Errorf("angular source root required for migration")

--- a/internal/workflow/request_test.go
+++ b/internal/workflow/request_test.go
@@ -1,0 +1,98 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeRequestCleansMigrationMappings(t *testing.T) {
+	tempDir := t.TempDir()
+	// create dummy mainframe path requirement using temp dir
+	mainframePath := filepath.Join(tempDir, "repo")
+	if err := os.Mkdir(mainframePath, 0o755); err != nil {
+		t.Fatalf("create repo dir: %v", err)
+	}
+
+	req := Request{
+		ProjectID: "proj1",
+		Mainframe: mainframePath,
+		Stacks:    []string{" cobol "},
+		TargetConfig: &TargetConfig{
+			Framework: "React",
+			Version:   "18",
+		},
+		MigrationConfig: &MigrationConfig{
+			AngularSourceRoot: " ./src/app ",
+			AngularVersion:    " 16 ",
+			ReactTargetRoot:   " ./target ",
+			ReactVersion:      "18",
+			PatternMapping: map[string]string{
+				" component ": " Component ",
+				"":            "skip",
+				"invalid":     " ",
+			},
+			ComponentLifecycleMapping: map[string]string{
+				" OnInit ":  " useEffect ",
+				"":          "",
+				"OnDestroy": " ",
+			},
+			DirectiveConversionMapping: map[string]string{
+				" *ngIf ": " conditional hook ",
+			},
+			ServiceContextMapping: map[string]string{
+				" AuthService ": " useAuthContext ",
+			},
+			PipeConversionMapping: map[string]string{
+				" date ": " formatDate ",
+			},
+			GuardRouteMapping: map[string]string{
+				" AuthGuard ": " requireAuth ",
+			},
+		},
+	}
+
+	normalized, err := normalizeRequest(req)
+	if err != nil {
+		t.Fatalf("normalizeRequest returned error: %v", err)
+	}
+
+	mig := normalized.MigrationConfig
+	if mig == nil {
+		t.Fatalf("expected migration config to be preserved")
+	}
+	if got := mig.AngularSourceRoot; got != "./src/app" {
+		t.Errorf("unexpected angular source root: %q", got)
+	}
+	if got := mig.PatternMapping; len(got) != 1 || got["component"] != "Component" {
+		t.Errorf("unexpected pattern mapping: %#v", got)
+	}
+	if got := mig.ComponentLifecycleMapping; len(got) != 1 || got["OnInit"] != "useEffect" {
+		t.Errorf("unexpected component lifecycle mapping: %#v", got)
+	}
+	if got := mig.DirectiveConversionMapping; len(got) != 1 || got["*ngIf"] != "conditional hook" {
+		t.Errorf("unexpected directive conversion mapping: %#v", got)
+	}
+	if got := mig.ServiceContextMapping; len(got) != 1 || got["AuthService"] != "useAuthContext" {
+		t.Errorf("unexpected service context mapping: %#v", got)
+	}
+	if got := mig.PipeConversionMapping; len(got) != 1 || got["date"] != "formatDate" {
+		t.Errorf("unexpected pipe conversion mapping: %#v", got)
+	}
+	if got := mig.GuardRouteMapping; len(got) != 1 || got["AuthGuard"] != "requireAuth" {
+		t.Errorf("unexpected guard route mapping: %#v", got)
+	}
+}
+
+func TestCleanMappingReturnsNilWhenEmpty(t *testing.T) {
+	if result := cleanMapping(nil); result != nil {
+		t.Fatalf("expected nil for nil input, got %#v", result)
+	}
+	input := map[string]string{
+		"":    "value",
+		"key": "",
+	}
+	if result := cleanMapping(input); result != nil {
+		t.Fatalf("expected nil for empty result, got %#v", result)
+	}
+}


### PR DESCRIPTION
## Summary
- add dedicated mapping categories to the migration configuration payload for Angular to React conversions
- normalize and validate all migration mapping inputs so empty/whitespace entries are stripped before workflows run
- cover the new sanitization behaviour with request-level unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68df19de3760832f8e44575c769e326a