### PR TITLE
Add migration-focused documentation artifact generation

### DIFF
--- a/internal/kb/types.go
+++ b/internal/kb/types.go
@@ -53,6 +53,10 @@ type ProgramDoc struct {
 	BusinessRulePrompts    []Doc              `json:"documentation_business_rules,omitempty"`
 	FunctionalPrompts      []Doc              `json:"documentation_functional_specs,omitempty"`
 	TechnicalPrompts       []Doc              `json:"documentation_technical_specs,omitempty"`
+	MigrationAssessments   []Doc              `json:"documentation_migration_assessments,omitempty"`
+	ComponentMappings      []Doc              `json:"documentation_component_mappings,omitempty"`
+	APICompatibility       []Doc              `json:"documentation_api_compatibility_matrices,omitempty"`
+	MigrationTimelines     []Doc              `json:"documentation_migration_timelines,omitempty"`
 	Dependencies           []GraphNeighbor    `json:"dependencies,omitempty"`
 	Impacts                []GraphNeighbor    `json:"impacts,omitempty"`
 	Related                []GraphNeighbor    `json:"related,omitempty"`

--- a/internal/retriever/retriever.go
+++ b/internal/retriever/retriever.go
@@ -664,6 +664,14 @@ func aggregateProgramDocs(docs []kb.Doc) map[string]*kb.ProgramDoc {
 			program.FunctionalPrompts = append(program.FunctionalPrompts, doc)
 		case "documentation_technical_spec":
 			program.TechnicalPrompts = append(program.TechnicalPrompts, doc)
+		case "documentation_migration_assessment":
+			program.MigrationAssessments = append(program.MigrationAssessments, doc)
+		case "documentation_component_mapping":
+			program.ComponentMappings = append(program.ComponentMappings, doc)
+		case "documentation_api_compatibility":
+			program.APICompatibility = append(program.APICompatibility, doc)
+		case "documentation_migration_timeline":
+			program.MigrationTimelines = append(program.MigrationTimelines, doc)
 		}
 	}
 	for _, program := range programs {
@@ -787,6 +795,38 @@ func aggregateProgramDocs(docs []kb.Doc) map[string]*kb.ProgramDoc {
 			}
 			return left.SourcePath < right.SourcePath
 		})
+		sort.Slice(program.MigrationAssessments, func(i, j int) bool {
+			left := program.MigrationAssessments[i]
+			right := program.MigrationAssessments[j]
+			if left.SourcePath == right.SourcePath {
+				return left.ID < right.ID
+			}
+			return left.SourcePath < right.SourcePath
+		})
+		sort.Slice(program.ComponentMappings, func(i, j int) bool {
+			left := program.ComponentMappings[i]
+			right := program.ComponentMappings[j]
+			if left.SourcePath == right.SourcePath {
+				return left.ID < right.ID
+			}
+			return left.SourcePath < right.SourcePath
+		})
+		sort.Slice(program.APICompatibility, func(i, j int) bool {
+			left := program.APICompatibility[i]
+			right := program.APICompatibility[j]
+			if left.SourcePath == right.SourcePath {
+				return left.ID < right.ID
+			}
+			return left.SourcePath < right.SourcePath
+		})
+		sort.Slice(program.MigrationTimelines, func(i, j int) bool {
+			left := program.MigrationTimelines[i]
+			right := program.MigrationTimelines[j]
+			if left.SourcePath == right.SourcePath {
+				return left.ID < right.ID
+			}
+			return left.SourcePath < right.SourcePath
+		})
 	}
 	return programs
 }
@@ -843,6 +883,10 @@ func (r *Retriever) enrichProgramDoc(ctx context.Context, base kb.ProgramDoc, em
 	var businessPrompts []kb.Doc
 	var functionalPrompts []kb.Doc
 	var technicalPrompts []kb.Doc
+	var migrationAssessments []kb.Doc
+	var componentMappings []kb.Doc
+	var apiCompatibility []kb.Doc
+	var migrationTimelines []kb.Doc
 	for _, point := range points {
 		doc, ok := docsByID[point.ID]
 		if !ok {
@@ -882,6 +926,14 @@ func (r *Retriever) enrichProgramDoc(ctx context.Context, base kb.ProgramDoc, em
 			functionalPrompts = appendIfMissing(functionalPrompts, doc)
 		case "documentation_technical_spec":
 			technicalPrompts = appendIfMissing(technicalPrompts, doc)
+		case "documentation_migration_assessment":
+			migrationAssessments = appendIfMissing(migrationAssessments, doc)
+		case "documentation_component_mapping":
+			componentMappings = appendIfMissing(componentMappings, doc)
+		case "documentation_api_compatibility":
+			apiCompatibility = appendIfMissing(apiCompatibility, doc)
+		case "documentation_migration_timeline":
+			migrationTimelines = appendIfMissing(migrationTimelines, doc)
 		}
 	}
 	enriched := base
@@ -929,6 +981,18 @@ func (r *Retriever) enrichProgramDoc(ctx context.Context, base kb.ProgramDoc, em
 	}
 	if len(technicalPrompts) > 0 {
 		enriched.TechnicalPrompts = technicalPrompts
+	}
+	if len(migrationAssessments) > 0 {
+		enriched.MigrationAssessments = migrationAssessments
+	}
+	if len(componentMappings) > 0 {
+		enriched.ComponentMappings = componentMappings
+	}
+	if len(apiCompatibility) > 0 {
+		enriched.APICompatibility = apiCompatibility
+	}
+	if len(migrationTimelines) > 0 {
+		enriched.MigrationTimelines = migrationTimelines
 	}
 	return r.attachGraph(ctx, enriched)
 }

--- a/internal/workflow/consolidated_documentation.go
+++ b/internal/workflow/consolidated_documentation.go
@@ -224,6 +224,14 @@ func consolidatedTitleForDoc(doc kb.Doc, info ConsolidatedDocumentInfo) string {
 		return "Functional Specification"
 	case docTypeTechnicalSpec:
 		return "Technical Specification"
+	case docTypeMigrationAssessment:
+		return "Migration Assessment Report"
+	case docTypeComponentMapping:
+		return "Component Mapping Guide"
+	case docTypeAPICompatibility:
+		return "API Compatibility Matrix"
+	case docTypeMigrationTimeline:
+		return "Migration Timeline"
 	case "metadata":
 		return "Program Metadata"
 	case "flow", "cics_flow", "mq_flow":

--- a/internal/workflow/documentation_test.go
+++ b/internal/workflow/documentation_test.go
@@ -106,7 +106,16 @@ func TestSummarizeDocumentationGeneratesArtifactsIncrementally(t *testing.T) {
 	if want := "documentation summaries"; !contains(summary, want) {
 		t.Fatalf("summary missing %q: %s", want, summary)
 	}
-	for _, want := range []string{"program flow prompts", "business rule prompts", "functional specification prompts", "technical specification prompts"} {
+	for _, want := range []string{
+		"program flow prompts",
+		"business rule prompts",
+		"functional specification prompts",
+		"technical specification prompts",
+		"migration assessment reports",
+		"component mapping guides",
+		"API compatibility matrices",
+		"migration timeline roadmaps",
+	} {
 		if !contains(summary, want) {
 			t.Fatalf("summary missing %q: %s", want, summary)
 		}
@@ -119,6 +128,7 @@ func TestSummarizeDocumentationGeneratesArtifactsIncrementally(t *testing.T) {
 	var crossFound, impactFound bool
 	var summaryDoc kb.Doc
 	var flowPromptDoc, businessPromptDoc, functionalPromptDoc, technicalPromptDoc kb.Doc
+	var migrationAssessmentDoc, componentMappingDoc, apiCompatibilityDoc, migrationTimelineDoc kb.Doc
 	for _, doc := range generated {
 		switch doc.Type {
 		case docTypeCrossReference:
@@ -141,6 +151,14 @@ func TestSummarizeDocumentationGeneratesArtifactsIncrementally(t *testing.T) {
 			functionalPromptDoc = doc
 		case docTypeTechnicalSpec:
 			technicalPromptDoc = doc
+		case docTypeMigrationAssessment:
+			migrationAssessmentDoc = doc
+		case docTypeComponentMapping:
+			componentMappingDoc = doc
+		case docTypeAPICompatibility:
+			apiCompatibilityDoc = doc
+		case docTypeMigrationTimeline:
+			migrationTimelineDoc = doc
 		}
 	}
 	if !crossFound || !impactFound {
@@ -160,6 +178,18 @@ func TestSummarizeDocumentationGeneratesArtifactsIncrementally(t *testing.T) {
 	}
 	if technicalPromptDoc.ID == "" {
 		t.Fatalf("expected technical specification prompt to be generated")
+	}
+	if migrationAssessmentDoc.ID == "" {
+		t.Fatalf("expected migration assessment prompt to be generated")
+	}
+	if componentMappingDoc.ID == "" {
+		t.Fatalf("expected component mapping prompt to be generated")
+	}
+	if apiCompatibilityDoc.ID == "" {
+		t.Fatalf("expected API compatibility prompt to be generated")
+	}
+	if migrationTimelineDoc.ID == "" {
+		t.Fatalf("expected migration timeline prompt to be generated")
 	}
 	if !contains(summaryDoc.Content, "technical specifications") {
 		t.Fatalf("expected technical specifications section in summary doc: %q", summaryDoc.Content)
@@ -185,6 +215,18 @@ func TestSummarizeDocumentationGeneratesArtifactsIncrementally(t *testing.T) {
 	if !contains(technicalPromptDoc.Content, "Technical Specification Prompt Template") || !contains(technicalPromptDoc.Content, "Data model considerations") {
 		t.Fatalf("expected technical prompt to mention data model considerations: %q", technicalPromptDoc.Content)
 	}
+	if !contains(migrationAssessmentDoc.Content, "Migration Assessment Prompt Template") || !contains(migrationAssessmentDoc.Content, "Legacy technologies") {
+		t.Fatalf("expected migration assessment prompt structure: %q", migrationAssessmentDoc.Content)
+	}
+	if !contains(componentMappingDoc.Content, "Component Mapping Prompt Template") || !contains(componentMappingDoc.Content, "Functional capabilities") {
+		t.Fatalf("expected component mapping prompt structure: %q", componentMappingDoc.Content)
+	}
+	if !contains(apiCompatibilityDoc.Content, "API Compatibility Matrix Prompt Template") || !contains(apiCompatibilityDoc.Content, "Legacy inputs") {
+		t.Fatalf("expected API compatibility prompt structure: %q", apiCompatibilityDoc.Content)
+	}
+	if !contains(migrationTimelineDoc.Content, "Migration Timeline Prompt Template") || !contains(migrationTimelineDoc.Content, "Key flow milestones") {
+		t.Fatalf("expected migration timeline prompt structure: %q", migrationTimelineDoc.Content)
+	}
 
 	mgr.workflowMu.Lock()
 	artifacts := mgr.workflows[projectID].state.DocumentationArtifacts
@@ -200,6 +242,10 @@ func TestSummarizeDocumentationGeneratesArtifactsIncrementally(t *testing.T) {
 		docTypeBusinessPrompt,
 		docTypeFunctionalSpec,
 		docTypeTechnicalSpec,
+		docTypeMigrationAssessment,
+		docTypeComponentMapping,
+		docTypeAPICompatibility,
+		docTypeMigrationTimeline,
 	} {
 		path, ok := artifacts[kind]
 		if !ok {

--- a/internal/workflow/runner.go
+++ b/internal/workflow/runner.go
@@ -340,6 +340,7 @@ func (m *Manager) summarizeDocumentation(ctx context.Context, projectID string) 
 	var programs, flows, businessRules, workingNotes, modernizations int
 	var docSummaries, crossRefs, impactAnalyses int
 	var flowPrompts, businessPrompts, functionalPrompts, technicalPrompts int
+	var migrationAssessments, componentMappings, apiMatrices, migrationTimelines int
 	for _, doc := range docs {
 		switch doc.Type {
 		case "metadata":
@@ -366,6 +367,14 @@ func (m *Manager) summarizeDocumentation(ctx context.Context, projectID string) 
 			functionalPrompts++
 		case docTypeTechnicalSpec:
 			technicalPrompts++
+		case docTypeMigrationAssessment:
+			migrationAssessments++
+		case docTypeComponentMapping:
+			componentMappings++
+		case docTypeAPICompatibility:
+			apiMatrices++
+		case docTypeMigrationTimeline:
+			migrationTimelines++
 		}
 	}
 	summaryParts := make([]string, 0, 5)
@@ -404,6 +413,18 @@ func (m *Manager) summarizeDocumentation(ctx context.Context, projectID string) 
 	}
 	if technicalPrompts > 0 {
 		summaryParts = append(summaryParts, fmt.Sprintf("%d technical specification prompts", technicalPrompts))
+	}
+	if migrationAssessments > 0 {
+		summaryParts = append(summaryParts, fmt.Sprintf("%d migration assessment reports", migrationAssessments))
+	}
+	if componentMappings > 0 {
+		summaryParts = append(summaryParts, fmt.Sprintf("%d component mapping guides", componentMappings))
+	}
+	if apiMatrices > 0 {
+		summaryParts = append(summaryParts, fmt.Sprintf("%d API compatibility matrices", apiMatrices))
+	}
+	if migrationTimelines > 0 {
+		summaryParts = append(summaryParts, fmt.Sprintf("%d migration timeline roadmaps", migrationTimelines))
 	}
 	if len(summaryParts) == 0 {
 		return "", fmt.Errorf("no documentation artifacts were generated")

--- a/web/ui/js/workflow.js
+++ b/web/ui/js/workflow.js
@@ -32,6 +32,10 @@ const artifactLabelMap = {
   documentation_summary: 'Documentation Summaries',
   documentation_cross_reference: 'Cross-Reference Maps',
   documentation_impact_analysis: 'Impact Assessments',
+  documentation_migration_assessment: 'Migration Assessment Reports',
+  documentation_component_mapping: 'Component Mapping Guides',
+  documentation_api_compatibility: 'API Compatibility Matrices',
+  documentation_migration_timeline: 'Migration Timeline Roadmaps',
   conversion_summary: 'Conversion Summaries',
   conversion_mapping: 'Conversion Mappings',
   conversion_source: 'Conversion Sources'


### PR DESCRIPTION
## Summary
- add migration assessment, component mapping, API compatibility, and migration timeline documentation flows to the workflow
- extend data structures, retriever enrichment, and consolidated titles for the new artifact families
- surface the new documentation downloads in the web UI and update regression tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68df3623acd4832fb7a75bf42aa0a491