### PR TITLE
Add migration review and performance documentation capabilities

### DIFF
--- a/internal/kb/types.go
+++ b/internal/kb/types.go
@@ -57,6 +57,10 @@ type ProgramDoc struct {
 	ComponentMappings      []Doc              `json:"documentation_component_mappings,omitempty"`
 	APICompatibility       []Doc              `json:"documentation_api_compatibility_matrices,omitempty"`
 	MigrationTimelines     []Doc              `json:"documentation_migration_timelines,omitempty"`
+	MigrationComplexities  []Doc              `json:"documentation_migration_complexities,omitempty"`
+	PatternRecommendations []Doc              `json:"documentation_pattern_recommendations,omitempty"`
+	MigratedCodeReviews    []Doc              `json:"documentation_migrated_code_reviews,omitempty"`
+	PerformanceComparisons []Doc              `json:"documentation_performance_comparisons,omitempty"`
 	Dependencies           []GraphNeighbor    `json:"dependencies,omitempty"`
 	Impacts                []GraphNeighbor    `json:"impacts,omitempty"`
 	Related                []GraphNeighbor    `json:"related,omitempty"`

--- a/internal/retriever/retriever.go
+++ b/internal/retriever/retriever.go
@@ -672,6 +672,14 @@ func aggregateProgramDocs(docs []kb.Doc) map[string]*kb.ProgramDoc {
 			program.APICompatibility = append(program.APICompatibility, doc)
 		case "documentation_migration_timeline":
 			program.MigrationTimelines = append(program.MigrationTimelines, doc)
+		case "documentation_migration_complexity":
+			program.MigrationComplexities = append(program.MigrationComplexities, doc)
+		case "documentation_pattern_recommendations":
+			program.PatternRecommendations = append(program.PatternRecommendations, doc)
+		case "documentation_migrated_code_review":
+			program.MigratedCodeReviews = append(program.MigratedCodeReviews, doc)
+		case "documentation_performance_comparison":
+			program.PerformanceComparisons = append(program.PerformanceComparisons, doc)
 		}
 	}
 	for _, program := range programs {
@@ -827,6 +835,38 @@ func aggregateProgramDocs(docs []kb.Doc) map[string]*kb.ProgramDoc {
 			}
 			return left.SourcePath < right.SourcePath
 		})
+		sort.Slice(program.MigrationComplexities, func(i, j int) bool {
+			left := program.MigrationComplexities[i]
+			right := program.MigrationComplexities[j]
+			if left.SourcePath == right.SourcePath {
+				return left.ID < right.ID
+			}
+			return left.SourcePath < right.SourcePath
+		})
+		sort.Slice(program.PatternRecommendations, func(i, j int) bool {
+			left := program.PatternRecommendations[i]
+			right := program.PatternRecommendations[j]
+			if left.SourcePath == right.SourcePath {
+				return left.ID < right.ID
+			}
+			return left.SourcePath < right.SourcePath
+		})
+		sort.Slice(program.MigratedCodeReviews, func(i, j int) bool {
+			left := program.MigratedCodeReviews[i]
+			right := program.MigratedCodeReviews[j]
+			if left.SourcePath == right.SourcePath {
+				return left.ID < right.ID
+			}
+			return left.SourcePath < right.SourcePath
+		})
+		sort.Slice(program.PerformanceComparisons, func(i, j int) bool {
+			left := program.PerformanceComparisons[i]
+			right := program.PerformanceComparisons[j]
+			if left.SourcePath == right.SourcePath {
+				return left.ID < right.ID
+			}
+			return left.SourcePath < right.SourcePath
+		})
 	}
 	return programs
 }
@@ -887,6 +927,10 @@ func (r *Retriever) enrichProgramDoc(ctx context.Context, base kb.ProgramDoc, em
 	var componentMappings []kb.Doc
 	var apiCompatibility []kb.Doc
 	var migrationTimelines []kb.Doc
+	var migrationComplexities []kb.Doc
+	var patternRecommendations []kb.Doc
+	var migratedCodeReviews []kb.Doc
+	var performanceComparisons []kb.Doc
 	for _, point := range points {
 		doc, ok := docsByID[point.ID]
 		if !ok {
@@ -934,6 +978,14 @@ func (r *Retriever) enrichProgramDoc(ctx context.Context, base kb.ProgramDoc, em
 			apiCompatibility = appendIfMissing(apiCompatibility, doc)
 		case "documentation_migration_timeline":
 			migrationTimelines = appendIfMissing(migrationTimelines, doc)
+		case "documentation_migration_complexity":
+			migrationComplexities = appendIfMissing(migrationComplexities, doc)
+		case "documentation_pattern_recommendations":
+			patternRecommendations = appendIfMissing(patternRecommendations, doc)
+		case "documentation_migrated_code_review":
+			migratedCodeReviews = appendIfMissing(migratedCodeReviews, doc)
+		case "documentation_performance_comparison":
+			performanceComparisons = appendIfMissing(performanceComparisons, doc)
 		}
 	}
 	enriched := base
@@ -993,6 +1045,18 @@ func (r *Retriever) enrichProgramDoc(ctx context.Context, base kb.ProgramDoc, em
 	}
 	if len(migrationTimelines) > 0 {
 		enriched.MigrationTimelines = migrationTimelines
+	}
+	if len(migrationComplexities) > 0 {
+		enriched.MigrationComplexities = migrationComplexities
+	}
+	if len(patternRecommendations) > 0 {
+		enriched.PatternRecommendations = patternRecommendations
+	}
+	if len(migratedCodeReviews) > 0 {
+		enriched.MigratedCodeReviews = migratedCodeReviews
+	}
+	if len(performanceComparisons) > 0 {
+		enriched.PerformanceComparisons = performanceComparisons
 	}
 	return r.attachGraph(ctx, enriched)
 }

--- a/internal/workflow/consolidated_documentation.go
+++ b/internal/workflow/consolidated_documentation.go
@@ -232,6 +232,14 @@ func consolidatedTitleForDoc(doc kb.Doc, info ConsolidatedDocumentInfo) string {
 		return "API Compatibility Matrix"
 	case docTypeMigrationTimeline:
 		return "Migration Timeline"
+	case docTypeMigrationComplexity:
+		return "Migration Complexity Assessment"
+	case docTypePatternRecommendations:
+		return "Pattern Recommendation Guide"
+	case docTypeMigratedCodeReview:
+		return "Migrated Component Code Review"
+	case docTypePerformanceComparison:
+		return "Performance Comparison Analysis"
 	case "metadata":
 		return "Program Metadata"
 	case "flow", "cics_flow", "mq_flow":

--- a/internal/workflow/documentation_test.go
+++ b/internal/workflow/documentation_test.go
@@ -115,6 +115,10 @@ func TestSummarizeDocumentationGeneratesArtifactsIncrementally(t *testing.T) {
 		"component mapping guides",
 		"API compatibility matrices",
 		"migration timeline roadmaps",
+		"migration complexity analyses",
+		"pattern recommendation guides",
+		"migrated component code reviews",
+		"performance comparison analyses",
 	} {
 		if !contains(summary, want) {
 			t.Fatalf("summary missing %q: %s", want, summary)
@@ -129,6 +133,8 @@ func TestSummarizeDocumentationGeneratesArtifactsIncrementally(t *testing.T) {
 	var summaryDoc kb.Doc
 	var flowPromptDoc, businessPromptDoc, functionalPromptDoc, technicalPromptDoc kb.Doc
 	var migrationAssessmentDoc, componentMappingDoc, apiCompatibilityDoc, migrationTimelineDoc kb.Doc
+	var migrationComplexityDoc, patternRecommendationsDoc kb.Doc
+	var migratedCodeReviewDoc, performanceComparisonDoc kb.Doc
 	for _, doc := range generated {
 		switch doc.Type {
 		case docTypeCrossReference:
@@ -159,6 +165,14 @@ func TestSummarizeDocumentationGeneratesArtifactsIncrementally(t *testing.T) {
 			apiCompatibilityDoc = doc
 		case docTypeMigrationTimeline:
 			migrationTimelineDoc = doc
+		case docTypeMigrationComplexity:
+			migrationComplexityDoc = doc
+		case docTypePatternRecommendations:
+			patternRecommendationsDoc = doc
+		case docTypeMigratedCodeReview:
+			migratedCodeReviewDoc = doc
+		case docTypePerformanceComparison:
+			performanceComparisonDoc = doc
 		}
 	}
 	if !crossFound || !impactFound {
@@ -190,6 +204,18 @@ func TestSummarizeDocumentationGeneratesArtifactsIncrementally(t *testing.T) {
 	}
 	if migrationTimelineDoc.ID == "" {
 		t.Fatalf("expected migration timeline prompt to be generated")
+	}
+	if migrationComplexityDoc.ID == "" {
+		t.Fatalf("expected migration complexity prompt to be generated")
+	}
+	if patternRecommendationsDoc.ID == "" {
+		t.Fatalf("expected pattern recommendation prompt to be generated")
+	}
+	if migratedCodeReviewDoc.ID == "" {
+		t.Fatalf("expected migrated component code review prompt to be generated")
+	}
+	if performanceComparisonDoc.ID == "" {
+		t.Fatalf("expected performance comparison prompt to be generated")
 	}
 	if !contains(summaryDoc.Content, "technical specifications") {
 		t.Fatalf("expected technical specifications section in summary doc: %q", summaryDoc.Content)
@@ -227,6 +253,18 @@ func TestSummarizeDocumentationGeneratesArtifactsIncrementally(t *testing.T) {
 	if !contains(migrationTimelineDoc.Content, "Migration Timeline Prompt Template") || !contains(migrationTimelineDoc.Content, "Key flow milestones") {
 		t.Fatalf("expected migration timeline prompt structure: %q", migrationTimelineDoc.Content)
 	}
+	if !contains(migrationComplexityDoc.Content, "Migration Complexity Assessment Prompt Template") || !contains(migrationComplexityDoc.Content, "Complexity drivers") {
+		t.Fatalf("expected migration complexity prompt structure: %q", migrationComplexityDoc.Content)
+	}
+	if !contains(patternRecommendationsDoc.Content, "Pattern Recommendation Prompt Template") || !contains(patternRecommendationsDoc.Content, "Lifecycle and flow checkpoints") {
+		t.Fatalf("expected pattern recommendation prompt structure: %q", patternRecommendationsDoc.Content)
+	}
+	if !contains(migratedCodeReviewDoc.Content, "Migrated Component Code Review Prompt Template") || !contains(migratedCodeReviewDoc.Content, "Data bindings and DTOs") {
+		t.Fatalf("expected migrated component code review prompt structure: %q", migratedCodeReviewDoc.Content)
+	}
+	if !contains(performanceComparisonDoc.Content, "Performance Comparison Prompt Template") || !contains(performanceComparisonDoc.Content, "Integration latency factors") {
+		t.Fatalf("expected performance comparison prompt structure: %q", performanceComparisonDoc.Content)
+	}
 
 	mgr.workflowMu.Lock()
 	artifacts := mgr.workflows[projectID].state.DocumentationArtifacts
@@ -246,6 +284,10 @@ func TestSummarizeDocumentationGeneratesArtifactsIncrementally(t *testing.T) {
 		docTypeComponentMapping,
 		docTypeAPICompatibility,
 		docTypeMigrationTimeline,
+		docTypeMigrationComplexity,
+		docTypePatternRecommendations,
+		docTypeMigratedCodeReview,
+		docTypePerformanceComparison,
 	} {
 		path, ok := artifacts[kind]
 		if !ok {

--- a/internal/workflow/runner.go
+++ b/internal/workflow/runner.go
@@ -341,6 +341,7 @@ func (m *Manager) summarizeDocumentation(ctx context.Context, projectID string) 
 	var docSummaries, crossRefs, impactAnalyses int
 	var flowPrompts, businessPrompts, functionalPrompts, technicalPrompts int
 	var migrationAssessments, componentMappings, apiMatrices, migrationTimelines int
+	var migrationComplexities, patternRecommendations, migratedCodeReviews, performanceComparisons int
 	for _, doc := range docs {
 		switch doc.Type {
 		case "metadata":
@@ -375,6 +376,14 @@ func (m *Manager) summarizeDocumentation(ctx context.Context, projectID string) 
 			apiMatrices++
 		case docTypeMigrationTimeline:
 			migrationTimelines++
+		case docTypeMigrationComplexity:
+			migrationComplexities++
+		case docTypePatternRecommendations:
+			patternRecommendations++
+		case docTypeMigratedCodeReview:
+			migratedCodeReviews++
+		case docTypePerformanceComparison:
+			performanceComparisons++
 		}
 	}
 	summaryParts := make([]string, 0, 5)
@@ -425,6 +434,18 @@ func (m *Manager) summarizeDocumentation(ctx context.Context, projectID string) 
 	}
 	if migrationTimelines > 0 {
 		summaryParts = append(summaryParts, fmt.Sprintf("%d migration timeline roadmaps", migrationTimelines))
+	}
+	if migrationComplexities > 0 {
+		summaryParts = append(summaryParts, fmt.Sprintf("%d migration complexity analyses", migrationComplexities))
+	}
+	if patternRecommendations > 0 {
+		summaryParts = append(summaryParts, fmt.Sprintf("%d pattern recommendation guides", patternRecommendations))
+	}
+	if migratedCodeReviews > 0 {
+		summaryParts = append(summaryParts, fmt.Sprintf("%d migrated component code reviews", migratedCodeReviews))
+	}
+	if performanceComparisons > 0 {
+		summaryParts = append(summaryParts, fmt.Sprintf("%d performance comparison analyses", performanceComparisons))
 	}
 	if len(summaryParts) == 0 {
 		return "", fmt.Errorf("no documentation artifacts were generated")

--- a/web/ui/js/workflow.js
+++ b/web/ui/js/workflow.js
@@ -36,6 +36,10 @@ const artifactLabelMap = {
   documentation_component_mapping: 'Component Mapping Guides',
   documentation_api_compatibility: 'API Compatibility Matrices',
   documentation_migration_timeline: 'Migration Timeline Roadmaps',
+  documentation_migration_complexity: 'Migration Complexity Analyses',
+  documentation_pattern_recommendations: 'Pattern Recommendation Guides',
+  documentation_migrated_code_review: 'Migrated Component Code Reviews',
+  documentation_performance_comparison: 'Performance Comparison Analyses',
   conversion_summary: 'Conversion Summaries',
   conversion_mapping: 'Conversion Mappings',
   conversion_source: 'Conversion Sources'


### PR DESCRIPTION
## Summary
- add new documentation artifact types that cover migration complexity, pattern recommendations, migrated component reviews, and performance comparisons
- integrate the new artifacts throughout enrichment, aggregation, consolidated views, and artifact packaging so they are versioned and downloadable
- update workflow summarisation, knowledge base types, and UI labels, with expanded tests exercising the richer documentation set

## Testing
- go test ./internal/workflow -run TestSummarizeDocumentationGeneratesArtifactsIncrementally -count=1 *(fails to complete because module downloads hang in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df387dbc18832f9a6a0cd6f87f2c3d